### PR TITLE
preserve input type in _to_diagonal

### DIFF
--- a/lib/PDL/IO/Touchstone.pm
+++ b/lib/PDL/IO/Touchstone.pm
@@ -1308,7 +1308,7 @@ sub _to_diagonal
 
 	if (!@dims || (@dims == 1 && $dims[0] == 1))
 	{
-		$ret = zeroes($n_ports,$n_ports);
+		$ret = zeroes($v->type,$n_ports,$n_ports);
 		$ret->diagonal(0,1) .= $v;
 	}
 	elsif (@dims == 1 && $dims[0] == $n_ports)


### PR DESCRIPTION
This seems to me like an actual bug in P:IO::Touchstone, and will help regardless of how I address https://github.com/PDLPorters/pdl/issues/511

If you like this, please merge and release this quite soon, which will help me.