### PR TITLE
Fix tests and use of complex functions on real data

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,6 +34,7 @@ my %WriteMakefileArgs = (
     },
     TEST_REQUIRES => {
 	'Test::More' => '0.88', # done_testing
+	'Test::PDL' => '0.21',
 	'File::Temp' => '0',
 	%REQUIRES
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,7 +33,7 @@ my %WriteMakefileArgs = (
         'ExtUtils::MakeMaker' => '0',
     },
     TEST_REQUIRES => {
-        'Test::More' => '0',
+	'Test::More' => '0.88', # done_testing
 	'File::Temp' => '0',
 	%REQUIRES
     },

--- a/lib/PDL/IO/Touchstone.pm
+++ b/lib/PDL/IO/Touchstone.pm
@@ -621,8 +621,8 @@ sub s_to_abcd
 	my $z01 = $Z_ref->slice(0,0)->reshape(1);
 	my $z02 = $Z_ref->slice(1,1)->reshape(1);
 
-	my $z01_conj = $z01->conj;
-	my $z02_conj = $z02->conj;
+	my $z01_conj = $z01->type->real ? $z01 : $z01->conj;
+	my $z02_conj = $z02->type->real ? $z02 : $z02->conj;
 
 	my ($S11, $S12, $S21, $S22) = m_to_pos_vecs($S);
 
@@ -682,8 +682,8 @@ sub abcd_to_s
 	my $z01 = $Z_ref->slice(0,0)->reshape(1);
 	my $z02 = $Z_ref->slice(1,1)->reshape(1);
 
-	my $z01_conj = $z01->conj;
-	my $z02_conj = $z02->conj;
+	my $z01_conj = $z01->type->real ? $z01 : $z01->conj;
+	my $z02_conj = $z02->type->real ? $z02 : $z02->conj;
 
 	my ($A, $B, $C, $D) = m_to_pos_vecs($ABCD);
 

--- a/t/01-snp-tests.t
+++ b/t/01-snp-tests.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,7 +5,7 @@ use PDL;
 use PDL::IO::Touchstone;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 200;
+use Test::More;
 
 # Cumulative error in PDL-to-perl-scalar conversion for long-double builds
 # requires a lower tolerance.  To prevent failing builds just because of
@@ -95,3 +93,5 @@ sub verify
 }
 
 unlink($fn);
+
+done_testing;

--- a/t/01-snp-tests.t
+++ b/t/01-snp-tests.t
@@ -16,7 +16,7 @@ use Test::More;
 # See here: https://github.com/PDLPorters/pdl/issues/405
 # and here: https://github.com/ebaudrez/Test-PDL/wiki/Rationale:-tolerances
 
-my $tolerance = 1e-6;
+use Test::PDL -atol => 1e-6;
 my ($fh, $fn) = tempfile();
 
 # This test iterates over a number of port sizes and output format types
@@ -86,10 +86,9 @@ sub verify
 {
 	my ($n_ports, $fmt1, $fmt2, $fmt_in, $m1, $m, $f, $f1, $orig_funit) = @_;
 
-	ok ( $fmt2 eq $fmt_in, "n_ports=$n_ports ($orig_funit) $fmt1 => $fmt2: format is equal");
-	ok ( sum($m1 - $m)->re < $tolerance, "n_ports=$n_ports ($orig_funit) $fmt1 => $fmt2: matrix real: error is < $tolerance");
-	ok ( sum($m1 - $m)->im < $tolerance, "n_ports=$n_ports ($orig_funit) $fmt1 => $fmt2: matrix imag: error is < $tolerance");
-	ok ( sum($f1 - $f) < $tolerance, "n_ports=$n_ports ($orig_funit) $fmt1 => $fmt2: freq: error is < $tolerance");
+	is $fmt2, $fmt_in, "n_ports=$n_ports ($orig_funit) $fmt1 => $fmt2: format is equal";
+	is_pdl $m1, $m, "n_ports=$n_ports ($orig_funit) $fmt1 => $fmt2: matrix real: error is < tolerance";
+	is_pdl $f1, $f->squeeze, "n_ports=$n_ports ($orig_funit) $fmt1 => $fmt2: freq: error is < tolerance";
 }
 
 unlink($fn);

--- a/t/02-snp-read.t
+++ b/t/02-snp-read.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,7 +5,7 @@ use PDL;
 use PDL::IO::Touchstone;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 1;
+use Test::More;
 
 my ($fh, $fn) = tempfile();
 
@@ -35,3 +33,5 @@ my $err = $@ // '';
 ok(scalar(@ret), "unusual first line numeric values ($err)");
 
 unlink($fn);
+
+done_testing;

--- a/t/03-read-test-data.t
+++ b/t/03-read-test-data.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,9 +5,7 @@ use PDL;
 use PDL::IO::Touchstone;
 use File::Temp qw/tempfile/;
 
-
-use Test::More tests => 4;
-
+use Test::More;
 
 my $datadir = 't/test-data';
 
@@ -24,3 +20,5 @@ foreach my $fn (@files)
 	#print $m . "\n";
 	ok($f->nelem > 0 && $m->nelem > 0, "$datadir/$fn");
 }
+
+done_testing;

--- a/t/04-yparams.t
+++ b/t/04-yparams.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,7 +5,7 @@ use PDL;
 use PDL::IO::Touchstone qw/rsnp s_to_y y_to_s /;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 10;
+use Test::More;
 
 # Cumulative error in PDL-to-perl-scalar conversion for long-double builds
 # requires a lower tolerance.  To prevent failing builds just because of
@@ -78,3 +76,4 @@ sub verify_one
 	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
 }
 
+done_testing;

--- a/t/04-yparams.t
+++ b/t/04-yparams.t
@@ -17,7 +17,7 @@ use Test::More;
 # See here: https://github.com/PDLPorters/pdl/issues/405
 # and here: https://github.com/ebaudrez/Test-PDL/wiki/Rationale:-tolerances
 
-my $tolerance = 1e-6;
+use Test::PDL -atol => 1e-6;
 
 my $datadir = 't/test-data';
 
@@ -43,8 +43,8 @@ my $Y = pdl [
     ]
   ];
 
-verify_one(s_to_y($S, 50), $Y, "(builtin)");
-verify_one(y_to_s($Y, 50), $S, "(builtin)");
+is_pdl s_to_y($S, 50), $Y, "(builtin)";
+is_pdl y_to_s($Y, 50), $S, "(builtin)";
 
 foreach my $fn (@files)
 {
@@ -58,22 +58,9 @@ foreach my $fn (@files)
 sub verify
 {
 	my ($m, $z0, $file, $f, $f_inv) = @_;
-
 	my $result = $f->($m, $z0);
 	my $inverse = $f_inv->($result, $z0);
-	
-	return verify_one($m, $inverse, $file);
-}
-
-sub verify_one
-{
-	my ($m, $inverse, $file) = @_;
-
-	my $re_err = sum(($m-$inverse)->re->abs);
-	my $im_err = sum(($m-$inverse)->im->abs);
-
-	ok($re_err < $tolerance, "$file: real error ($re_err) < $tolerance");
-	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
+	is_pdl $m, $inverse, $file;
 }
 
 done_testing;

--- a/t/05-zparams.t
+++ b/t/05-zparams.t
@@ -7,7 +7,7 @@ use File::Temp qw/tempfile/;
 
 use Test::More;
 
-my $tolerance = 1e-6;
+use Test::PDL -atol => 1e-6;
 
 my $datadir = 't/test-data';
 
@@ -33,37 +33,22 @@ my $Z = pdl [
   ];
 
 
-verify_one(s_to_z($S, 50), $Z, "(builtin)");
-verify_one(z_to_s($Z, 50), $S, "(builtin)");
+is_pdl s_to_z($S, 50), $Z, "(builtin)";
+is_pdl z_to_s($Z, 50), $S, "(builtin)";
 
 foreach my $fn (@files, @ARGV)
 {
 	my ($f, $m, $param_type, $z0, $comments, $fmt, $funit, $orig_f_unit) = rsnp($fn);
-
 	next unless $param_type eq 'S';
-
 	verify($m, $z0, "$fn (S->Z->S):", \&s_to_z => \&z_to_s);
 }
 
 sub verify
 {
 	my ($m, $z0, $file, $f, $f_inv) = @_;
-
 	my $result = $f->($m, $z0);
 	my $inverse = $f_inv->($result, $z0);
-	
-	return verify_one($m, $inverse, $file);
-}
-
-sub verify_one
-{
-	my ($m, $inverse, $file) = @_;
-
-	my $re_err = sum(($m-$inverse)->re->abs);
-	my $im_err = sum(($m-$inverse)->im->abs);
-
-	ok($re_err < $tolerance, "$file: real error ($re_err) < $tolerance");
-	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
+	is_pdl $m, $inverse, $file;
 }
 
 done_testing;

--- a/t/05-zparams.t
+++ b/t/05-zparams.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,7 +5,7 @@ use PDL;
 use PDL::IO::Touchstone qw/rsnp s_to_z z_to_s /;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 8;
+use Test::More;
 
 my $tolerance = 1e-6;
 
@@ -68,3 +66,4 @@ sub verify_one
 	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
 }
 
+done_testing;

--- a/t/06-aparams.t
+++ b/t/06-aparams.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,7 +5,7 @@ use PDL;
 use PDL::IO::Touchstone qw/rsnp s_to_abcd abcd_to_s /;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 8;
+use Test::More;
 
 my $tolerance = 1e-6;
 
@@ -68,3 +66,4 @@ sub verify_one
 	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
 }
 
+done_testing;

--- a/t/06-aparams.t
+++ b/t/06-aparams.t
@@ -7,7 +7,7 @@ use File::Temp qw/tempfile/;
 
 use Test::More;
 
-my $tolerance = 1e-6;
+use Test::PDL -atol => 1e-6;
 
 my $datadir = 't/test-data';
 
@@ -33,8 +33,8 @@ my $A = pdl [
 		]
 	];
 
-verify_one(s_to_abcd($S, 50), $A, "(builtin)");
-verify_one(abcd_to_s($A, 50), $S, "(builtin)");
+is_pdl s_to_abcd($S, 50), $A, {require_equal_types=>0, test_name=>"(builtin)"};
+is_pdl abcd_to_s($A, 50), $S, {require_equal_types=>0, test_name=>"(builtin)"};
 
 foreach my $fn (@files, @ARGV)
 {
@@ -48,22 +48,9 @@ foreach my $fn (@files, @ARGV)
 sub verify
 {
 	my ($m, $z0, $file, $f, $f_inv) = @_;
-
 	my $result = $f->($m, $z0);
 	my $inverse = $f_inv->($result, $z0);
-	
-	return verify_one($m, $inverse, $file);
-}
-
-sub verify_one
-{
-	my ($m, $inverse, $file) = @_;
-
-	my $re_err = sum(($m-$inverse)->re->abs);
-	my $im_err = sum(($m-$inverse)->im->abs);
-
-	ok($re_err < $tolerance, "$file: real error ($re_err) < $tolerance");
-	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
+	is_pdl $m, $inverse, {require_equal_types=>0, test_name=>$file}; # coming back as cldouble AND cdouble, error?
 }
 
 done_testing;

--- a/t/10-s_port_z.t
+++ b/t/10-s_port_z.t
@@ -6,8 +6,7 @@ use PDL::IO::Touchstone qw/rsnp s_port_z n_ports/;
 use File::Temp qw/tempfile/;
 
 use Test::More;
-
-my $tolerance = 1e-6;
+use Test::PDL -atol => 1e-6;
 
 my $datadir = 't/test-data';
 
@@ -18,11 +17,9 @@ my $S = pdl [
 		],
 	];
 
-my $zin  = s_port_z($S, 50, 1);
-ok(abs($zin - pdl(50.1070651124653-158.985376613117*i() )) < $tolerance, "(builtin) Port 1");
-
-my $zout = s_port_z($S, 50, 2);
-ok(abs($zout - pdl(50.1070651124653-158.985376613117*i() )) < $tolerance, "(builtin) Port 2");
+my $exp = pdl([50.1070651124653-158.985376613117*i()]);
+is_pdl s_port_z($S, 50, 1), $exp, "(builtin) Port 1";
+is_pdl s_port_z($S, 50, 2), $exp, "(builtin) Port 2";
 
 foreach my $fn (qw(t/test-data/IDEAL_SHORT.s2p))
 {
@@ -32,9 +29,7 @@ foreach my $fn (qw(t/test-data/IDEAL_SHORT.s2p))
 
 	for my $p (1..n_ports($m))
 	{
-		my $z = s_port_z($m, $z0, $p);
-		my $err = sum(abs($z - 50));
-		ok($err < $tolerance, "$fn port-$p: error: $err");
+		is_pdl s_port_z($m, $z0, $p), cdouble(50,50), "$fn port-$p";
 	}
 }
 

--- a/t/10-s_port_z.t
+++ b/t/10-s_port_z.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,7 +5,7 @@ use PDL;
 use PDL::IO::Touchstone qw/rsnp s_port_z n_ports/;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 4;
+use Test::More;
 
 my $tolerance = 1e-6;
 
@@ -40,3 +38,4 @@ foreach my $fn (qw(t/test-data/IDEAL_SHORT.s2p))
 	}
 }
 
+done_testing;

--- a/t/100-mdif-rewrite.t
+++ b/t/100-mdif-rewrite.t
@@ -6,10 +6,7 @@ use PDL::IO::MDIF;
 use File::Temp qw/tempfile/;
 
 use Test::More;
-
-my $tolerance = 1e-6;
-
-use Data::Dumper;
+use Test::PDL -atol => 1e-6;
 
 my ($fh, $fn) = tempfile();
 END {close $fh; unlink $fn};
@@ -31,27 +28,14 @@ for (my $i = 0; $i < @$mdf; $i++)
 	ok($$m1 != $$m2, "m refs are different");
 	ok($$z01 != $$z02, "z0 refs are different");
 
-	verify_one($f1, $f2, "freqs");
-	verify_one($m1, $m2, "matrix");
-	verify_one($z01, $z02, "z0");
+	is_pdl $f1, $f2, "freqs";
+	is_pdl $m1, $m2, "matrix";
+	is_pdl $z01, $z02, "z0";
 
 	foreach my $n (qw/param_type comments fmt funit orig_f_unit/)
 	{
 		ok(eval "qq{\$${n}1} eq qq{\$${n}2}", "$n is correct");
 	}
-}
-
-#print Dumper $mdf;
-
-sub verify_one
-{
-	my ($m, $inverse, $file) = @_;
-
-	my $re_err = sum(($m-$inverse)->re->abs);
-	my $im_err = sum(($m-$inverse)->im->abs);
-
-	ok($re_err < $tolerance, "$file: real error ($re_err) < $tolerance");
-	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
 }
 
 done_testing;

--- a/t/100-mdif-rewrite.t
+++ b/t/100-mdif-rewrite.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,7 +5,7 @@ use PDL;
 use PDL::IO::MDIF;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 743;
+use Test::More;
 
 my $tolerance = 1e-6;
 
@@ -55,3 +53,5 @@ sub verify_one
 	ok($re_err < $tolerance, "$file: real error ($re_err) < $tolerance");
 	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
 }
+
+done_testing;

--- a/t/11-m_interpolate.t
+++ b/t/11-m_interpolate.t
@@ -10,7 +10,7 @@ use Test::More;
 # For each file, rescale the frequency range smaller by 1kHz and then grow it
 # back to see if the values are close.  Tolerance is a bit low, but thats ok
 # because we know we are probably interpolating outside of frequency ranges:
-my $tolerance = 1e-3;
+use Test::PDL -atol => 1e-6;
 
 my $datadir = 't/test-data';
 
@@ -41,21 +41,10 @@ foreach my $fn (@files, @ARGV)
 	my ($f2, $m2) = m_interpolate($f_new, $m_new,
 		{ freq_range => "$f_min - $f_max x$f_count", quiet => 1 });
 
-	verify_one($f, $f2, "$fn: f");
-	verify_one($m, $m2, "$fn: m");
+	is_pdl $f, $f2, "$fn: f";
+	is_pdl $m, $m2, "$fn: m";
 
 	ok($f->nelem == $f_new->nelem && $f->nelem == $f2->nelem, "$fn: correct freq counts");
-}
-
-sub verify_one
-{
-	my ($m, $inverse, $file) = @_;
-
-	my $re_err = sum(($m-$inverse)->re->abs);
-	my $im_err = sum(($m-$inverse)->im->abs);
-
-	ok($re_err < $tolerance, "$file: real error ($re_err) < $tolerance");
-	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
 }
 
 done_testing;

--- a/t/11-m_interpolate.t
+++ b/t/11-m_interpolate.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,7 +5,7 @@ use PDL;
 use PDL::IO::Touchstone qw/rsnp m_interpolate f_is_uniform /;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 10;
+use Test::More;
 
 # For each file, rescale the frequency range smaller by 1kHz and then grow it
 # back to see if the values are close.  Tolerance is a bit low, but thats ok
@@ -60,3 +58,4 @@ sub verify_one
 	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
 }
 
+done_testing;

--- a/t/12-m_interpolate-range.t
+++ b/t/12-m_interpolate-range.t
@@ -6,43 +6,31 @@ use PDL::IO::Touchstone qw/rsnp m_interpolate f_is_uniform /;
 use File::Temp qw/tempfile/;
 
 use Test::More;
-my $tolerance = 1e-6;
+use Test::PDL -atol => 1e-6;
 
 my ($f, $m, $param_type, $z0, $comments, $fmt, $funit, $orig_f_unit) = rsnp('t/test-data/cha3024-99f-lna.s2p');
 
 
 my ($f_new, $m_new) =  m_interpolate($f, $m, '1.5e9, 2e9 - 3e9 x5, 4e9 += 2e9 x3');
-verify_one($f_new,
+is_pdl $f_new,
 	pdl(1.5e+09, 2e+09, 2.25e+09, 2.5e+09, 2.75e+09, 3e+09, 4e+09, 6e+09, 8e+09),
-	"range interpolation - text");
+	"range interpolation - text";
 
 ($f_new, $m_new) =  m_interpolate($f, $m, [1.5e9, '2e9 - 3e9 x5', '4e9 += 2e9 x3']);
-verify_one($f_new,
+is_pdl $f_new,
 	pdl(1.5e+09, 2e+09, 2.25e+09, 2.5e+09, 2.75e+09, 3e+09, 4e+09, 6e+09, 8e+09),
-	"range interpolation - arrayref");
+	"range interpolation - arrayref";
 
 ($f_new, $m_new) =  m_interpolate($f, $m,
 	[ 1.5e+09, 2e+09, 2.25e+09, 2.5e+09, 2.75e+09, 3e+09, 4e+09, 6e+09, 8e+09 ]);
-verify_one($f_new,
+is_pdl $f_new,
 	pdl(1.5e+09, 2e+09, 2.25e+09, 2.5e+09, 2.75e+09, 3e+09, 4e+09, 6e+09, 8e+09),
-	"range interpolation - arrayref scalar");
+	"range interpolation - arrayref scalar";
 
 ($f_new, $m_new) =  m_interpolate($f, $m,
 	pdl [ 1.5e+09, 2e+09, 2.25e+09, 2.5e+09, 2.75e+09, 3e+09, 4e+09, 6e+09, 8e+09 ]);
-verify_one($f_new,
+is_pdl $f_new,
 	pdl(1.5e+09, 2e+09, 2.25e+09, 2.5e+09, 2.75e+09, 3e+09, 4e+09, 6e+09, 8e+09),
-	"range interpolation - PDL");
-
-
-sub verify_one
-{
-	my ($m, $inverse, $file) = @_;
-
-	my $re_err = sum(($m-$inverse)->re->abs);
-	my $im_err = sum(($m-$inverse)->im->abs);
-
-	ok($re_err < $tolerance, "$file: real error ($re_err) < $tolerance");
-	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
-}
+	"range interpolation - PDL";
 
 done_testing;

--- a/t/12-m_interpolate-range.t
+++ b/t/12-m_interpolate-range.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -7,7 +5,7 @@ use PDL;
 use PDL::IO::Touchstone qw/rsnp m_interpolate f_is_uniform /;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 8;
+use Test::More;
 my $tolerance = 1e-6;
 
 my ($f, $m, $param_type, $z0, $comments, $fmt, $funit, $orig_f_unit) = rsnp('t/test-data/cha3024-99f-lna.s2p');
@@ -47,3 +45,4 @@ sub verify_one
 	ok($im_err < $tolerance, "$file: imag error ($im_err) < $tolerance");
 }
 
+done_testing;

--- a/t/20-y_calcs.t
+++ b/t/20-y_calcs.t
@@ -24,7 +24,7 @@ use File::Temp qw/tempfile/;
 
 use Test::More;
 
-my $tolerance = 1e-3;
+use Test::PDL -atol => 1e-3;
 
 my $datadir = 't/test-data/muRata';
 
@@ -99,7 +99,7 @@ foreach my $fn (@files, @ARGV)
 	foreach my $v (sort keys %$ref_vals)
 	{
 		my $value = $vals{$v} // '(undef)';
-		verify_one($ref_vals->{$v}, $vals{$v}, "$fn: $v=$value");
+		is_pdl $vals{$v}//pdl([0]), pdl([$ref_vals->{$v}]), "$fn: $v=$value";
 	}
 
 	# Parallel and series calculations on ferrite beads don't always behave
@@ -115,16 +115,16 @@ foreach my $fn (@files, @ARGV)
 
 	if ($vals{cap} > 0)
 	{
-		verify_one($pp_vals{cap}, $vals{cap}*2, "$fn: cap: parallel");
-		verify_one($ss_vals{cap}, $vals{cap}/2, "$fn: cap: series");
+		is_pdl $pp_vals{cap}, $vals{cap}*2, "$fn: cap: parallel";
+		is_pdl $ss_vals{cap}, $vals{cap}/2, "$fn: cap: series";
 
 		ok($vals{Qc} > 0, "$fn: capacitive reactance");
 	}
 
 	if ($vals{ind} > 0)
 	{
-		verify_one($pp_vals{ind}, $vals{ind}/2, "$fn: ind: parallel");
-		verify_one($ss_vals{ind}, $vals{ind}*2, "$fn: ind: series");
+		is_pdl $pp_vals{ind}, $vals{ind}/2, "$fn: ind: parallel";
+		is_pdl $ss_vals{ind}, $vals{ind}*2, "$fn: ind: series";
 		ok($vals{Ql} > 0, "$fn: inductive reactance");
 	}
 
@@ -156,23 +156,6 @@ foreach my $fn (@files, @ARGV)
 }
 
 done_testing;
-
-sub verify_one
-{
-	my ($m, $inverse, $msg) = @_;
-
-
-	ok((defined($m) && defined($inverse)) || (!defined($m) && !defined($inverse)),
-		"$msg: " . (defined($m) ? 'defined' : 'undef'));
-
-	return if (!defined($m) || !defined($inverse));
-
-	my $re_err = sum(($m-$inverse)->re->abs);
-	my $im_err = sum(($m-$inverse)->im->abs);
-
-	ok($re_err < $tolerance, "$msg: real error ($re_err) < $tolerance");
-	ok($im_err < $tolerance, "$msg: imag error ($im_err) < $tolerance");
-}
 
 sub build_vals
 {

--- a/t/20-y_calcs.t
+++ b/t/20-y_calcs.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 use strict;
 use warnings;
 
@@ -24,7 +22,7 @@ use PDL::IO::Touchstone qw/rsnp
 	/;
 use File::Temp qw/tempfile/;
 
-use Test::More tests => 263;
+use Test::More;
 
 my $tolerance = 1e-3;
 
@@ -156,6 +154,8 @@ foreach my $fn (@files, @ARGV)
 =cut
 
 }
+
+done_testing;
 
 sub verify_one
 {


### PR DESCRIPTION
A change I made to main PDL to forbid `carg`, `conj` and especially `im` on real data caused test failures in this code. Much of that is avoided by just using Test::PDL, which as you can see here acts like your `verify_one` (but is quicker as it now uses one PP function instead of several).

I've now adjusted the two places where `conj` was used so it's only done for complex data. That also means it will avoid wasted computation.

If you like this, please merge and release it so PDL's CI doesn't show failures from this. Thanks!